### PR TITLE
refactor(cli): replace manual env parsing with dotenv

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "packages/@kimzuni/templify": {
       "name": "@kimzuni/templify",
-      "version": "2.0.0",
+      "version": "2.2.0",
       "devDependencies": {
         "tsdown": "^0.18.4",
       },
@@ -28,13 +28,14 @@
       "name": "@kimzuni/templify-cli",
       "version": "2.0.0",
       "bin": {
-        "templify": "dist/index.mjs",
-        "tply": "dist/index.mjs",
+        "templify": "dist/index.cjs",
+        "tply": "dist/index.cjs",
       },
       "dependencies": {
         "@commander-js/extra-typings": "^14.0.0",
         "@kimzuni/templify": "workspace:^",
         "commander": "^14.0.2",
+        "dotenv": "^17.4.2",
       },
       "devDependencies": {
         "tsdown": "0.18.3",
@@ -301,6 +302,8 @@
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "dot-prop": ["dot-prop@5.3.0", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q=="],
+
+    "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
     "dts-resolver": ["dts-resolver@2.1.3", "", { "peerDependencies": { "oxc-resolver": ">=11.0.0" }, "optionalPeers": ["oxc-resolver"] }, "sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw=="],
 

--- a/packages/@kimzuni/templify-cli/package.json
+++ b/packages/@kimzuni/templify-cli/package.json
@@ -46,7 +46,8 @@
   "dependencies": {
     "@commander-js/extra-typings": "^14.0.0",
     "@kimzuni/templify": "workspace:^",
-    "commander": "^14.0.2"
+    "commander": "^14.0.2",
+    "dotenv": "^17.4.2"
   },
   "devDependencies": {
     "tsdown": "0.18.3"

--- a/packages/@kimzuni/templify-cli/src/utils.ts
+++ b/packages/@kimzuni/templify-cli/src/utils.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import fs from "node:fs/promises";
+import dotenv from "dotenv";
 import * as tply from "@kimzuni/templify";
 
 import type { Options } from "./types";
@@ -76,31 +77,21 @@ export async function loadTemplate(
  */
 export async function loadContext(KEY_VALUE: string[], opts: Options): Promise<tply.Context> {
 	const { dataFile, fromEnv } = opts;
-	const env = fromEnv ? { ...process.env } : {};
+	const processEnv = fromEnv ? { ...process.env } : {};
 
 	let json: tply.Context = {};
+	let envFileLines: string[] = [];
 	if (dataFile !== undefined) {
 		const text = await fs.readFile(dataFile, "utf-8").then(x => x.trim());
 		if (text[0] === "{" || text[0] === "[") {
 			json = JSON.parse(text) as tply.Context;
 		} else {
-			KEY_VALUE = text.split("\n").concat(KEY_VALUE);
+			envFileLines = text.split("\n");
 		}
 	}
 
-	const keyValues: Record<string, string> = {};
-	for (let curr of KEY_VALUE) {
-		const idx = curr.indexOf("#");
-		if (idx !== -1) curr = curr.slice(0, idx).trimEnd();
-		const split = curr.split("=");
-		const key = split.shift()?.trim();
-		let value = split.join("=").trim();
-		const hasQuote = ["\"", "'", "`"].includes(value[0]);
-		if (hasQuote) value = value.slice(1, -1);
-		if (key) keyValues[key] = value;
-	}
-
-	return Object.assign(env, json, keyValues);
+	const keyValues = dotenv.parse([...KEY_VALUE, ...envFileLines].join("\n"));
+	return Object.assign(processEnv, json, keyValues);
 }
 
 /**


### PR DESCRIPTION
## 🚀 Overview

This PR refactors the CLI's environment variable parsing mechanism by integrating the battle-tested `dotenv` package. 

Previously, the CLI relied on a custom parsing logic to handle `.env` strings. While functional, it was inherently fragile and difficult to maintain when dealing with edge cases like manual quote stripping, inline comments, and multiline values. By adopting `dotenv`, we ensure robust, standard-compliant environment variable parsing.

## 🛠️ Key Changes

- **Add `dotenv` Dependency:** Introduced `dotenv` to safely and reliably parse environment variables.
- **Remove Custom Parser:** Stripped out the fragile, hard-coded string manipulation logic (e.g., manual quote handling, comment slicing).

## 💡 Impact

- Improved edge-case handling for complex `.env` configurations.
- Cleaner, more maintainable CLI codebase.
- Standardized behavior aligned with the broader Node.js ecosystem.